### PR TITLE
Fixed bug that reset noCategory attribute

### DIFF
--- a/creditsBot.py
+++ b/creditsBot.py
@@ -60,7 +60,7 @@ async def run(ctx):
             profile.topRole = rawProfile['topRole']
           profiles.append(profile)
         for rawRole in rawOldCredits['roles']:
-          role = Role(rawRole['name'], rawRole['color'], 'noCategory' in rawRole)
+          role = Role(rawRole['name'], rawRole['color'], rawRole['noCategory'])
           roles.append(role)
 
     # Find all roles

--- a/uncreditedRoles.txt
+++ b/uncreditedRoles.txt
@@ -1,13 +1,13 @@
 @everyone
-Archiver
 Trial Curator
 Timeout
 Notification Squad
-Archiver
-Former Staff
 MOTAS Finder
 Nitro Booster
-Moderator [pt]
-Moderator [it]
-Moderator [fr]
-Moderator [de]
+Bunnyposter
+Bot
+Archiver
+FPFSS Notification Service
+PF Scrape
+Guardian
+BlueBot


### PR DESCRIPTION
Fixed bug that caused roles to always be reset to `"noCategory": true`. Also updated the uncredited roles