### PR TITLE
Add uncredited users feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Make a file `token.txt` and put your Bot token inside it
 
 Put any roles you don't want to credit inside `uncreditedRoles.txt`. Remember that @everyone is a role.
 
+Put any users that should be excluded from the credits inside `uncreditedUsers.txt`.
+
 Put any roles that you want to be top roles by default inside `topRoles.txt`.
 
 Put any users you want the Bot to run commands for inside `users.txt`

--- a/creditsBot.py
+++ b/creditsBot.py
@@ -9,14 +9,17 @@ intents.members = True
 bot = commands.Bot(command_prefix='>', intents=intents)
 token = ''
 valid_users = []
-uncredited = []
+uncredited_users = []
+uncredited_roles = []
 top_roles = []
 with open('token.txt', 'r') as f:
   token = f.read().replace('\n', '')
 with open('users.txt', 'r') as f:
   valid_users = map(int, f.read().splitlines())
+with open('uncreditedUsers.txt', 'r') as f:
+  uncredited_users = [int(id) for id in f.read().splitlines()]
 with open('uncreditedRoles.txt', 'r') as f:
-  uncredited = f.read().splitlines()
+  uncredited_roles = f.read().splitlines()
 with open('topRoles.txt', 'r') as f:
   top_roles = f.read().splitlines()
 role_order = {}
@@ -76,7 +79,7 @@ async def run(ctx):
     # Find all roles
     for i, r in enumerate(guild.roles):
       role_order[r.name] = i
-      if r.name not in uncredited:
+      if r.name not in uncredited_roles:
         role = None
         roleIndex = None
         # Load existing role if possible
@@ -100,8 +103,8 @@ async def run(ctx):
     await bot.request_offline_members(guild)
     for member in guild.members:
       # Filter out excluded roles
-      memberRoles = list(filter(lambda r: r.name not in uncredited, member.roles))
-      if len(memberRoles) > 0:
+      memberRoles = list(filter(lambda r: r.name not in uncredited_roles, member.roles))
+      if len(memberRoles) > 0 and member.id not in uncredited_users:
         # If roles remain, must be credited
         profile = None
         profileIndex = None


### PR DESCRIPTION
The bot will now exclude users with IDs listed in `uncreditedUsers.txt` from being added to the credits. This allows us to honor contributors' requests not to appear in the credits without removing their roles on Discord.