### PR TITLE
Add credited users feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Put any roles you don't want to credit inside `uncreditedRoles.txt`. Remember th
 
 Put any users that should be excluded from the credits inside `uncreditedUsers.txt`.
 
+Put any users that should always be included in the credits (even if they don't have a credited role) inside `creditedUsers.txt`.
+
 Put any roles that you want to be top roles by default inside `topRoles.txt`.
 
 Put any users you want the Bot to run commands for inside `users.txt`

--- a/creditsBot.py
+++ b/creditsBot.py
@@ -16,6 +16,8 @@ with open('token.txt', 'r') as f:
   token = f.read().replace('\n', '')
 with open('users.txt', 'r') as f:
   valid_users = map(int, f.read().splitlines())
+with open('creditedUsers.txt', 'r') as f:
+  credited_users = [int(id) for id in f.read().splitlines()]
 with open('uncreditedUsers.txt', 'r') as f:
   uncredited_users = [int(id) for id in f.read().splitlines()]
 with open('uncreditedRoles.txt', 'r') as f:
@@ -104,7 +106,7 @@ async def run(ctx):
     for member in guild.members:
       # Filter out excluded roles
       memberRoles = list(filter(lambda r: r.name not in uncredited_roles, member.roles))
-      if len(memberRoles) > 0 and member.id not in uncredited_users:
+      if (member.id in credited_users or len(memberRoles) > 0) and member.id not in uncredited_users:
         # If roles remain, must be credited
         profile = None
         profileIndex = None


### PR DESCRIPTION
The bot will always add/update users with IDs listed in `creditedUsers.txt` to the credits. This allows us to add contributors to the credits without giving them a role on Discord.